### PR TITLE
audiolat: Add midi playout functionality

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
+    <uses-feature android:name="android.software.midi" android:required="true"/>
 
     <application
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/facebook/audiolat/MainActivity.java
+++ b/app/src/main/java/com/facebook/audiolat/MainActivity.java
@@ -5,10 +5,23 @@ import android.content.pm.PackageManager;
 import android.media.AudioAttributes;
 import android.media.AudioDeviceInfo;
 import android.media.AudioManager;
+import android.media.midi.MidiDevice;
+import android.media.midi.MidiDeviceInfo;
+import android.media.midi.MidiManager;
+import android.media.midi.MidiOutputPort;
+import android.media.midi.MidiReceiver;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.v4.app.ActivityCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.CompoundButton;
+import android.widget.ListView;
+import android.widget.ToggleButton;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
@@ -16,7 +29,7 @@ import java.util.ArrayList;
 
 public class MainActivity extends AppCompatActivity {
   public static final String LOG_ID = "audiolat";
-
+  Handler mHandler;
   // default values
   int mSampleRate = 16000;
   int mTimeout = 15;
@@ -31,12 +44,16 @@ public class MainActivity extends AppCompatActivity {
   public String JAVAAUDIO = "javaaudio";
   String mApi = AAUDIO;
   int mJavaaudioPerformanceMode = 0;
-
+  boolean mMidiMode = false;
+  ListView mDeviceListView;
+  ArrayAdapter<String> mMidiDevices;
+  MidiManager mMidiManager;
   static {
     System.loadLibrary("audiolat");
   }
 
   public native int runAAudio(TestSettings settings);
+  public native void midiSignal(long nanotime);
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
@@ -49,10 +66,6 @@ public class MainActivity extends AppCompatActivity {
       int REQUEST_ALL_PERMISSIONS = 0x4562;
       ActivityCompat.requestPermissions(this, permissions, REQUEST_ALL_PERMISSIONS);
     }
-
-    setContentView(R.layout.activity_main);
-
-    android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_URGENT_AUDIO);
 
     try {
       // read CLI arguments
@@ -94,7 +107,21 @@ public class MainActivity extends AppCompatActivity {
           String atpm = extras.getString("atpm");
           mJavaaudioPerformanceMode = Integer.parseInt(atpm);
         }
+        if (extras.containsKey("midi")) {
+          mMidiMode = true;
+        } else {
+        }
       }
+
+      if (mMidiMode) {
+        setContentView(R.layout.activity_midi);
+      } else {
+        setContentView(R.layout.activity_main);
+      }
+      String file_path = "/sdcard/audiolat";
+
+      android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_URGENT_AUDIO);
+
       // choose end signal file
       String filePath = setupSignalSource();
 
@@ -119,31 +146,120 @@ public class MainActivity extends AppCompatActivity {
 
       // begin a thread that implements the experiment
       final String recFilePath = filePath;
-      Thread t = new Thread(new Runnable() {
-        @Override
-        public void run() {
-          // pack all the info together into settings
-          TestSettings settings = new TestSettings();
-          settings.endSignal = endSignal;
-          settings.endSignalSize = endSignalSize / 2; /* 16 bits */
-          settings.beginSignal = beginSignal;
-          settings.beginSignalSize = beginSignalSize / 2; /* 16 bits */
-          settings.timeout = mTimeout; // sec
-          settings.outputFilePath = recFilePath;
-          settings.sampleRate = mSampleRate;
-          settings.recordBufferSize = mRecordBufferSize;
-          settings.playoutBufferSize = mPlayoutBufferSize;
-          settings.usage = mUsage;
-          settings.timeBetweenSignals = mTimeBetweenSignals;
-          settings.javaaudioPerformanceMode = mJavaaudioPerformanceMode;
-          runExperiment(mApi, settings);
-        }
-      });
-      t.start();
+      if (!mMidiMode) {
+        Thread t = new Thread(new Runnable() {
+          @Override
+          public void run() {
+            // pack all the info together into settings
+            TestSettings settings = new TestSettings();
+            settings.endSignal = endSignal;
+            settings.endSignalSize = endSignalSize / 2; /* 16 bits */
+            settings.beginSignal = beginSignal;
+            settings.beginSignalSize = beginSignalSize / 2; /* 16 bits */
+            settings.timeout = mTimeout; // sec
+            settings.outputFilePath = recFilePath;
+            settings.sampleRate = mSampleRate;
+            settings.recordBufferSize = mRecordBufferSize;
+            settings.playoutBufferSize = mPlayoutBufferSize;
+            settings.usage = mUsage;
+            settings.timeBetweenSignals = mTimeBetweenSignals;
+            settings.javaaudioPerformanceMode = mJavaaudioPerformanceMode;
+            runExperiment(mApi, settings);
+          }
+        });
+        t.start();
+      }else{
+        // pack all the info together into settings
+        final TestSettings settings = new TestSettings();
+        settings.endSignal = endSignal;
+        settings.endSignalSize = endSignalSize / 2; /* 16 bits */
+        settings.beginSignal = beginSignal;
+        settings.beginSignalSize = beginSignalSize / 2; /* 16 bits */
+        settings.timeout = mTimeout; // sec
+        settings.outputFilePath = recFilePath;
+        settings.sampleRate = mSampleRate;
+        settings.recordBufferSize = mRecordBufferSize;
+        settings.playoutBufferSize = mPlayoutBufferSize;
+        settings.usage = mUsage;
+        settings.timeBetweenSignals = -1; //no automatic playback please
+        settings.javaaudioPerformanceMode = mJavaaudioPerformanceMode;
 
-    } catch (IOException e) {
+        mMidiManager = (MidiManager)this.getSystemService(Context.MIDI_SERVICE);
+        mHandler = Handler.createAsync(getMainLooper());
+        mMidiManager.registerDeviceCallback(new MidiManager.DeviceCallback(){
+          public void onDeviceAdded(MidiDeviceInfo device) {
+            populateMidiDeviceList();
+          }
+
+          public void	onDeviceRemoved(MidiDeviceInfo device) {
+            populateMidiDeviceList();
+          }
+        }, mHandler);
+        mDeviceListView = findViewById(R.id.deviceList);
+        mDeviceListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+          @Override
+          public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+            String[] device_desc = mDeviceListView.getItemAtPosition(position).toString().split("-");
+            int dev_id = Integer.valueOf(device_desc[1]);
+
+            MidiDeviceInfo[] infos = mMidiManager.getDevices();
+            for (MidiDeviceInfo info: infos ) {
+              if (info.getId() == dev_id) {
+                if (info.getOutputPortCount() > 0) {
+                  mMidiManager.openDevice(info, new MidiManager.OnDeviceOpenedListener() {
+                    @Override
+                    public void onDeviceOpened(MidiDevice device) {
+                      // Just open the first port (and in most cases the only one)
+                      MidiOutputPort output = device.openOutputPort(0);
+                      if (output != null) {
+                        output.onConnect(new MidiReceiver() {
+                          @Override
+                          public void onSend(byte[] msg, int offset, int count, long timestamp) throws IOException {
+                            midiSignal(timestamp);
+                            long time = System.nanoTime();
+                            Log.d(LOG_ID, "Got midi: timestamp = "+timestamp + " sys time "+time  + " diff: "+(time - timestamp));
+                          }
+                        });
+                      } else {
+                        Log.d(LOG_ID, "Failed to first port");
+                      }
+                    }
+                  }, mHandler);
+
+                  (new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                      runExperiment(mApi, settings);
+                    }
+                  })).start();
+
+                } else {
+                  Log.d(LOG_ID, "No output ports available");
+                }
+              }
+            }
+          }
+        });
+
+        populateMidiDeviceList();
+      }
+
+
+    } catch(IOException e) {
       e.printStackTrace();
     }
+
+  }
+
+  void populateMidiDeviceList() {
+    MidiDeviceInfo[] infos = mMidiManager.getDevices();
+    ArrayList<String> devices = new ArrayList<>();
+    for (MidiDeviceInfo info: infos) {
+      Bundle bundle = info.getProperties();
+      devices.add(bundle.get("product").toString() + "-" + info.getId());
+    }
+    mMidiDevices = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_dropdown_item, devices);
+    mDeviceListView.setAdapter(mMidiDevices);
   }
 
   private String setupSignalSource() {
@@ -231,7 +347,6 @@ public class MainActivity extends AppCompatActivity {
 
     AudioDeviceInfo info = adevs[0]; // Take the first (and best)
     settings.deviceId = info.getId();
-
     if (api.equals(AAUDIO)) {
       Log.d(LOG_ID, "Calling native (AAudio) API");
       int status = runAAudio(settings);
@@ -241,7 +356,9 @@ public class MainActivity extends AppCompatActivity {
       javaAudio.runJavaAudio(this, settings);
     }
 
+
     Log.d(LOG_ID, "Done");
+
     System.exit(0);
   }
 }

--- a/app/src/main/res/layout/activity_midi.xml
+++ b/app/src/main/res/layout/activity_midi.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/active"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ListView
+        android:id="@+id/deviceList"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/activatedBackgroundIndicator"
+        android:choiceMode="singleChoice"
+        android:clickable="true"
+        android:defaultFocusHighlightEnabled="true"
+        android:drawSelectorOnTop="true"
+        android:listSelector="?android:attr/textColorHighlight"
+        tools:layout_editor_absoluteX="149dp"
+        tools:layout_editor_absoluteY="361dp" />
+
+</android.support.constraint.ConstraintLayout>

--- a/scripts/calc_delay.py
+++ b/scripts/calc_delay.py
@@ -3,13 +3,10 @@
 import argparse
 import numpy as np
 import pandas as pd
-
-
-# minimum full audio latency distance
-MIN_DIST_SEC = 0.002
-
-
-def find_pairs(data, debug=0):
+debug = 0
+MIN_DIST_SEC = 0.01
+def find_pairs(data):
+    files = pd.unique(data['reference'])
 
     # The one with most hits is the "begin" signal
     begin_filename = None
@@ -19,7 +16,6 @@ def find_pairs(data, debug=0):
         if ref_len > max_len:
             max_len = ref_len
             begin_filename = signal_filename
-
     matches = []
 
     begin_signals = data.loc[data['reference'] == begin_filename]
@@ -45,13 +41,15 @@ def find_pairs(data, debug=0):
     return result
 
 
-def parse_input_file(filename):
+def parse_input_file(filename, options):
     # 135263,16.907875,47,audio.wav
     data = pd.read_csv(filename)
     if data is None:
         print('warning: No data on {filename}')
         return None, None, None
     pairs = find_pairs(data)
+    if options.output is not None:
+        pairs.to_csv(options.output, index=False)
     samples = len(pairs['latency'])
     if samples == 0:
         print('warning: No data on {filename}')
@@ -69,7 +67,7 @@ def main():
     options = parser.parse_args()
 
     for filename in options.files:
-        average_sec, stddev_sec, samples = parse_input_file(filename)
+        average_sec, stddev_sec, samples = parse_input_file(filename, options)
         if average_sec is None:
             continue
         print(f'filename: {filename} average_sec: {average_sec} '

--- a/scripts/find_transient.py
+++ b/scripts/find_transient.py
@@ -112,7 +112,7 @@ def main():
     parser = argparse.ArgumentParser(description='')
     parser.add_argument('files', nargs='+', help='file(s) to analyze (video)')
     parser.add_argument('-m', '--marker')
-    parser.add_argument('-l', '--leading', type=bool, default=True)
+    parser.add_argument('-l', '--leading', type=bool, default=False)
     parser.add_argument('-t', '--threshold', type=int, default=90)
 
     options = parser.parse_args()
@@ -176,13 +176,12 @@ def main():
         match = []
         for point in markers.iterrows():
             time=point[1]['time']
-            print(f"time: {time}")
             if options.leading:                
+               #limit to one second and 10ms in the future
+               signals = data.loc[(data['time'] >  time + 0.010) & (data['time'] < time + 1)]
+            else:
                 #limit to one second and 10ms in the past
                 signals = data.loc[(data['time'] <  time - 0.005) & (data['time'] > time - 1)]
-            else:
-                #limit to one second and 10ms in the future
-                signals = data.loc[(data['time'] >  time + 0.010) & (data['time'] < time + 1)]
             if len(signals) > 0:
                 end = signals.iloc[0]
                 match.append([round(end['time'],2), abs(round(end['time'] - time,2)), input_name, round(end['local max level'],2), round(end['file max level'],2), round(end['rms'],2)])

--- a/scripts/find_transient.py
+++ b/scripts/find_transient.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# (c) Facebook, Inc. and its affiliates. Confidential and proprietary.
+
+import soundfile as sf
+import pandas as pd
+import argparse
+import numpy as np
+from math import log10
+
+def floatToDB(val):
+    """
+    Calculates the dB values from a floating point representation
+    ranging between -1.0 to 1.0 where 1.0 is 0 dB
+    """
+    if val <= 0:
+        return -100.0
+    else:
+        return 20.0 * log10(val)
+
+def audio_levels(audiofile, start=0, end=-1):
+    """
+        Calculates rms and max peak level in dB
+    """
+
+    blocksize = audiofile.channels * audiofile.samplerate * 10
+    peak_level = [0] * audiofile.channels
+    rms = [0] * audiofile.channels
+    peak = [0] * audiofile.channels
+    total_level = [0] * audiofile.channels
+    crest = [0] * audiofile.channels
+    bias = [0] * audiofile.channels
+    block_counter = 0
+    audiofile.seek(start)
+
+    while audiofile.tell() < audiofile.frames:
+        data = audiofile.read(blocksize)
+        for channel in range(0, audiofile.channels):
+            if audiofile.channels == 1:
+                data_ = data
+            else:
+                data_ = data[:, channel]
+            total_level[channel] += np.sum(data_)
+            rms[channel] += np.mean(np.square(data_))
+            peak[channel] = max(abs(data_))
+            if (peak[channel] > peak_level[channel]):
+                peak_level[channel] = peak[channel]
+        block_counter += 1
+
+    for channel in range(0, audiofile.channels):
+        rms[channel] = np.sqrt(rms[channel] / block_counter)
+        crest[channel] = round(floatToDB(peak_level[channel] / rms[channel]), 2)
+        bias[channel] = round(floatToDB(total_level[channel] / (block_counter * 10 * audiofile.samplerate)), 2)
+        rms[channel] = round(floatToDB(rms[channel]), 2)
+        peak_level[channel] = round(floatToDB(peak_level[channel]), 2)
+
+    return rms, peak_level, crest, bias
+
+def match_buffers(data, ref_data, threshold=95, gain=0):
+    """
+        Tries to find ref_data in data using correlation measurement.
+    """
+    size = len(ref_data)
+
+    if gain != 0:
+        data = np.multiply(data, gain)
+    corr = np.correlate(data, ref_data)
+
+    val = max(corr)
+    index = np.where(corr == val)[0][0]
+    cc = np.corrcoef(data[index: index + size], ref_data)[1, 0] * 100
+    if np.isnan(cc):
+        cc = 0
+    return index, int(cc)
+
+def find_markers(options, dist_data, sampelrate):
+    template = []
+    if options.marker[-3:] == 'wav':
+        ref = sf.SoundFile(options.marker, 'r')
+        template = ref.read()
+    else:
+        print('Only wav file supported')
+        exit(0)
+
+    max_pos = 0
+
+    read_len = int(1.5 * sampelrate)
+    counter = 0
+    last = 0
+    split_times = []
+    while last <= len(dist_data) - len(template):
+        index, cc = match_buffers(dist_data[last:last + read_len],
+                                  template)
+
+        index += last
+        pos = index - max_pos
+        if pos < 0:
+            pos = 0
+        if cc > options.threshold:
+            time = pos / sampelrate
+            split_times.append([pos, time, cc])
+
+        last += read_len  # len(template)
+        counter += 1
+
+    data = pd.DataFrame()
+    labels = ['sample', 'time', 'correlation']
+    data = pd.DataFrame.from_records(
+        split_times, columns=labels, coerce_float=True)
+    return data;
+            
+def main():
+    parser = argparse.ArgumentParser(description='')
+    parser.add_argument('files', nargs='+', help='file(s) to analyze (video)')
+    parser.add_argument('-m', '--marker')
+    parser.add_argument('-l', '--leading', type=bool, default=True)
+    parser.add_argument('-t', '--threshold', type=int, default=90)
+
+    options = parser.parse_args()
+
+    total_max = -100;
+    rms = -100;
+     
+    
+    for input_name in options.files:
+        print(f'** Check for {input_name}')
+        template = []
+        ref_data = []
+        split_times = []
+        if input_name[-3:] == 'wav':
+            audiofile = sf.SoundFile(input_name, 'r')
+        else:
+            print('Only wav file supported')
+            exit(0)
+
+        rms, peak_level, crest, bias = audio_levels(audiofile)
+        blocksize = int(0.5 * audiofile.samplerate)
+        audiofile.seek(0);
+        block_counter = 0
+        audio_data = audiofile.read();
+        markers = find_markers(options, audio_data, audiofile.samplerate)
+        index = 0
+        last_trigg_point = -1
+        triggered = False
+        
+        threshold = peak_level[0] - 18
+        #remove click
+        print(str( audio_data[audio_data >=1]))
+        audio_data[audio_data >=1] = 0
+      
+        while index + blocksize < len(audio_data):
+            data = audio_data[index:index + blocksize]
+            local_max = np.argmax(data)
+            local_max_db = floatToDB(data[local_max])
+            if (local_max_db >= threshold) and not triggered:
+                triggered = True
+                split_times.append([index+ local_max, (index+ local_max)/audiofile.samplerate, local_max_db])
+            elif (local_max_db < threshold - 6) and triggered:
+                triggered = False
+                
+            if local_max_db > total_max:
+                total_max = local_max_db;
+            
+            index  += int(blocksize/8)
+          
+      
+            
+        data = pd.DataFrame()
+        labels = ['sample', 'time', 'local max level']
+        data = pd.DataFrame.from_records(
+            split_times, columns=labels, coerce_float=True)
+        data['file max level'] = total_max
+        data['rms'] = rms[0]
+        
+        print(f"{data}")
+        print(f"{markers}")
+        match = []
+        for point in markers.iterrows():
+            time=point[1]['time']
+            print(f"time: {time}")
+            if options.leading:                
+                #limit to one second and 10ms in the past
+                signals = data.loc[(data['time'] <  time - 0.005) & (data['time'] > time - 1)]
+            else:
+                #limit to one second and 10ms in the future
+                signals = data.loc[(data['time'] >  time + 0.010) & (data['time'] < time + 1)]
+            if len(signals) > 0:
+                end = signals.iloc[0]
+                match.append([round(end['time'],2), abs(round(end['time'] - time,2)), input_name, round(end['local max level'],2), round(end['file max level'],2), round(end['rms'],2)])
+
+        labels = ['time', 'delay', 'file', 'local max level','file max level', 'rms']
+        matches = pd.DataFrame.from_records(
+            match, columns=labels, coerce_float=True)
+        matches.to_csv(input_name + '.peaks_match.csv', index=False)
+                        
+        print(f"{matches}")
+        
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -1,37 +1,68 @@
 #!/bin/bash
+
+
+function capture_logcat {
+    adb logcat -c
+    adb logcat -v threadtime > ${1}&
+    sid=($!)
+    trap "kill ${sid[@]}" INT
+}
+
 samplerate=$1
 timeout=$2
 playbuff=$3
-recbuff=$3
+recbuff=$4
+api=$5
+signal=$6
+
+# <device>.aaudio.aec_on.agc_on.ns_on.cond_on.exp_<id>.csv 
+# <device>.aaudio.aec_off.agc_off.ns_off.cond_on.exp_<id>.csv
+test_id=$7 #.aaudio.aec_off.agc_off.ns_off.cond_on.exp_<id>
+
 script=${BASH_SOURCE[0]}
 sdir=${script%/*}
-
+wdir=$(pwd)
 adb shell am force-stop com.facebook.audiolat
 files=$(adb shell ls /sdcard/audiolat*.raw)
 for file in ${files}; do
     adb shell rm "${file}"
 done
-adb shell am start -n com.facebook.audiolat/.MainActivity -e sr "${samplerate}" -e t "${timeout}" -e rbs "${playbuff}" -e pbs "${recbuff}"
+capture_logcat audiolat_tmp.txt
+#PERFORMANCE_MODE_LOW_LATENCY 1
+adb shell am start -n com.facebook.audiolat/.MainActivity -e sr "${samplerate}" -e t "${timeout}" -e rbs "${playbuff}" -e pbs "${recbuff}" -e api "${api}" -e signal "${signal}" -e usage 2 -e atm 1
 sleep "${timeout}"
 # give me some startup margin
-sleep 3
+sleep 1
+logfile="${wdir}/audiolat_${samplerate}Hz_${playbuff}_${recbuff}.logcat"
+match_log="${wdir}/audiolat_${samplerate}Hz_match_times.log"
+cp audiolat_tmp.txt ${logfile}
+rm audiolat_tmp.txt
 files=$(adb shell ls /sdcard/audiolat*.raw)
-for file in ${files}; do
-    adb pull "${file}"
-    input=${file##*/}
-    output=${file##*/}.wav
-    ffmpeg -f s16le -ar "${samplerate}" -i "${input}" -ar "${samplerate}"  "${output}" -y
-    begin_signal="${sdir}/../audio/begin_signal.wav"
-    end_signal="${sdir}/../audio/chirp2_48k_300ms.wav"
 
-    if [[ ${samplerate} -eq 16000 ]];then
-        end_signal=${sdir}/../audio/chirp2_16k_300ms.wav
-    elif [[ ${samplerate} -eq 8000 ]];then
-        end_signal="${sdir}/../audio/chirp2_8k_300ms.wav"
-    fi
-    echo "Find pulse"
-    "${sdir}/find_pulses.py" "${begin_signal}" "${end_signal}" -i "${output}" -sr "${samplerate}" -t 20
+file=${files[0]}
+adb pull "${file}"
+input=${file##*/}
+output=${file##*/}.wav
+ffmpeg -f s16le -ar "${samplerate}" -i "${input}" -ar "${samplerate}"  "${output}" -y
 
-done
-    
+begin_signal="${sdir}/../audio/begin_signal.wav"
+end_signal="${input#*audiolat_}"
+end_signal="${sdir}/../audio/${end_signal%*.raw}.wav"
+
+echo "find pulses"
+"${sdir}/find_pulses.py" "${begin_signal}" "${end_signal}" -i "${output}" -sr "${samplerate}" -t 35
+
+echo "calc delays"
+"${sdir}/calc_delay.py"  "${output}.csv" -o "${wdir}/${test_id}.match.csv" > "${match_log}"
+
+echo "parse data to ${test_id}.mean.csv"
+echo "${sdir}/parse_data.sh ${logfile} ${match_log} ${sampelrate} ${wdir}/${test_id}.mean.csv"
+device=$("${sdir}/parse_data.sh" "${logfile}" "${match_log}" "${sampelrate}" "${test_id}.mean.csv")
+echo "Change names"
+mv ${output} ${device}.${test_id}.wav
+mv ${output}.csv ${device}.${test_id}.csv
+mv ${logfile} ${device}.${test_id}.logcat
+mv "${wdir}/${test_id}.match.csv" "${wdir}/${device}.${test_id}.match.csv"
+rm ${input}
+
 


### PR DESCRIPTION
Adds "-e midi 1" to command line to enable midi.
A list of available devices will be shown on screen.
Test starts when one device is selected by clicking on it.
Test will continue until the timeout has passed and
a recorded file can be pulled the normal way.

The find_transient.py script can be used to find transients
and signal in a wave file. The following call is used to
find a transient trigger before the marker signal.
>find_transients.py -m end.wav capture.wav

-l means marker leading and is used to fing a transient
that is after the marker signal.
>find_transients.py -l -m begin.wav capture.wav

Signed-off-by: Johan Blome <jblome@fb.com>