### PR TITLE
audiolat: Lowered threshold for hits in find_peaks.py script

### DIFF
--- a/scripts/find_transient.py
+++ b/scripts/find_transient.py
@@ -144,7 +144,7 @@ def main():
         index = 0
         triggered = False
 
-        threshold = peak_level[0] - 18
+        threshold = peak_level[0] - 6
         # remove click
         print(str(audio_data[audio_data >= 1]))
         audio_data[audio_data >= 1] = 0


### PR DESCRIPTION
The hits had a consistent peak level, lower the threshold for peaks
cleaned up false positives when looking for transients.