### PR TITLE
audiolat: Added a build target for sdk 28

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,13 +138,21 @@ Second build the encapp app:
 ```
 $ ./gradlew clean
 $ ./gradlew build
-$ ./gradlew installDebug
+$ ./gradlew installAudiolatDebug
+```
+If running the application targeted at sdk 28 the last command should be:
+```
+$ ./gradlew installAudiolat_sdk28Debug
 ```
 
 (2) Run the app for the very first time to get permissions
 
 ```
 $ adb shell am start -n com.facebook.audiolat/.MainActivity
+```
+If running the application targeted at sdk 28 the command is:
+```
+$ adb shell am start -n com.facebook.audiolat.sdk28/com.facebook.audiolat.MainActivity 
 ```
 
 The very first time you run the app, you will receive 2 requests to give permissions to the app. The app needs:
@@ -189,11 +197,13 @@ Run the command. You should hear some chirps (a signal of continuously increasin
 
 (2) Analyze results
 
-The recorded file can be found in `/sdcard/audiolat*.raw`. First pull it
+The recorded file can be found in `/storage/emulated/0/Android/data/com.facebook.audiolat/files/audiolat*.raw`. First pull it
 and convert it to pcm s16 wav.
+If running the application targeted at sdk 28 the path is:
+`/storage/emulated/0/Android/data/com.facebook.audiolat.sdk28/files/audiolat*.raw`
 
 ```
-$ adb pull /sdcard/audiolat_chirp2_16k_300ms.raw .
+$ adb pull /storage/emulated/0/Android/data/com.facebook.audiolat/files/audiolat_chirp2_16k_300ms.raw .
 $ ffmpeg -f s16le -acodec pcm_s16le -ac 1 -ar 16000 -i audiolat_chirp2_16k_300ms.raw audiolat_chirp2_16k_300ms.raw.wav
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,7 @@ android {
 
     defaultConfig {
         applicationId "com.facebook.audiolat"
-        minSdkVersion 29
-        targetSdkVersion 29
+
         versionCode 1
         versionName "1.0"
 
@@ -49,6 +48,33 @@ android {
             prefab true
         }
 
+    }
+
+    flavorDimensions "version"
+    productFlavors {
+        audiolat {
+            dimension "version"
+            minSdkVersion 29
+            targetSdkVersion 29
+            externalNativeBuild {
+                cmake {
+                    targets "audiolat"
+                }
+            }
+        }
+        audiolat_sdk28 {
+            dimension "version"
+            minSdkVersion 28
+            targetSdkVersion 28
+            applicationIdSuffix ".sdk28"
+            versionNameSuffix "-sdk28"
+            externalNativeBuild {
+                cmake {
+                    targets "audiolat_sdk28"
+                }
+            }
+
+        }
     }
 
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.facebook.audiolat">
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO"/>
     <uses-feature android:name="android.software.midi" android:required="true"/>
 

--- a/app/src/main/jni/CMakeLists.txt
+++ b/app/src/main/jni/CMakeLists.txt
@@ -4,63 +4,21 @@
 # Sets the minimum version of CMake required to build the native library.
 
 cmake_minimum_required(VERSION 3.10.2)
-
-# Declares and names the project.
-
 project("cmaketest")
 
-# Creates and names a library, sets it as either STATIC
-# or SHARED, and provides the relative paths to its source code.
-# You can define multiple libraries, and CMake builds them for you.
-# Gradle automatically packages shared libraries with your APK.
+add_library(audiolat SHARED aaudio.cpp oboe.cpp)
+add_library(audiolat_sdk28  SHARED  aaudio.cpp oboe.cpp)
 
-add_library( # Sets the name of the library.
-             audiolat
-
-             # Sets the library as a shared library.
-             SHARED
-
-             # Provides a relative path to your source file(s).
-            aaudio.cpp oboe.cpp
-            )
-
-# Searches for a specified prebuilt library and stores the path as a
-# variable. Because CMake includes system libraries in the search path by
-# default, you only need to specify the name of the public NDK library
-# you want to add. CMake verifies that the library exists before
-# completing its build.
-
-find_library( # Sets the name of the path variable.
-              log-lib
-
-              # Specifies the name of the NDK library that
-              # you want CMake to locate.
-              log )
-
-find_library( # Sets the name of the path variable.
-        amidi-lib
-
-        # Specifies the name of the NDK library that
-        # you want CMake to locate.
-        amidi )
-
-find_library( # Sets the name of the path variable.
-        aaudio-lib
-
-        # Specifies the name of the NDK library that
-        # you want CMake to locate.
-        aaudio
-        )
+find_library(log-lib log)
+find_library(aaudio-lib aaudio)
 
 find_package (oboe REQUIRED CONFIG)
-# Specifies libraries CMake should link to your target library. You
-# can link multiple libraries, such as libraries you define in this
-# build script, prebuilt third-party libraries, or system libraries.
-
-target_link_libraries( # Specifies the target library.
-                        audiolat
-                       ${log-lib}
-                       ${aaudio-lib}
-                       ${amidi-lib}
-                        oboe::oboe
-                       )
+target_link_libraries(audiolat
+                        ${log-lib}
+                        ${aaudio-lib}
+                        amidi
+                        oboe::oboe)
+target_link_libraries(audiolat_sdk28
+                        ${log-lib}
+                        ${aaudio-lib}
+                        oboe::oboe)

--- a/scripts/find_transient.py
+++ b/scripts/find_transient.py
@@ -15,6 +15,7 @@ def main():
     parser.add_argument('-t', '--threshold', type=int, default=90)
     parser.add_argument('-p', '--peak_span', type=int, default=18)
     parser.add_argument('--limit_marker', type=float, default=-1)
+    parser.add_argument('-d', '--max_distance', type=int, default=.5)
     parser.add_argument('-v', '--verbose', required=False, action='store_true')
 
     options = parser.parse_args()
@@ -84,13 +85,13 @@ def main():
         for point in markers.iterrows():
             time = point[1]['time']
             if options.leading:
-                # limit to one second and 10ms in the future
+                # limit to .5 second and 10ms in the future
                 signals = data.loc[(data['time'] > time + 0.010) &
-                                   (data['time'] < time + 1)]
+                                   (data['time'] < time + options.max_distance)]
             else:
-                # limit to one second and 5ms in the past
+                # limit to .5 seconds and 5ms in the past
                 signals = data.loc[(data['time'] < time - 0.005) &
-                                   (data['time'] > time - 1)]
+                                   (data['time'] > time - options.max_distance)]
             if len(signals) > 0:
                 end = signals.iloc[0]
                 match.append([
@@ -102,7 +103,7 @@ def main():
                     round(end['rms'], 2),
                 ])
 
-        labels = ['time', 'delay', 'file', 'local max level',
+        labels = ['timestamp', 'latency', 'file', 'local max level',
                   'file max level', 'rms']
         matches = pd.DataFrame.from_records(
             match, columns=labels, coerce_float=True)

--- a/scripts/run_test.sh
+++ b/scripts/run_test.sh
@@ -15,6 +15,7 @@ recbuff=$4
 api=$5
 signal=$6
 
+sdk_version=$(adb shell getprop ro.build.version.sdk)
 
 # <device>.aaudio.aec_on.agc_on.ns_on.cond_on.exp_<id>.csv
 # <device>.aaudio.aec_off.agc_off.ns_off.cond_on.exp_<id>.csv
@@ -24,7 +25,12 @@ midi=$8
 script=${BASH_SOURCE[0]}
 sdir=${script%/*}
 wdir=$(pwd)
-files=$(adb shell ls /sdcard/audiolat*.raw)
+if [[ $sdk_version -ge 29 ]]; then
+    files=$(adb shell ls /storage/emulated/0/Android/data/com.facebook.audiolat/files/audiolat*.raw)
+else
+    files=$(adb shell ls /storage/emulated/0/Android/data/com.facebook.audiolat.sdk28/files/audiolat*.raw)
+fi
+
 for file in ${files}; do
     adb shell rm "${file}"
 done
@@ -32,10 +38,21 @@ capture_logcat audiolat_tmp.txt
 
 # -e midi ${midi}
 #PERFORMANCE_MODE_LOW_LATENCY 1
+testtype=""
 if [ -z ${midi} ]; then
-    adb shell am start -S -n com.facebook.audiolat/.MainActivity -e sr "${samplerate}" -e t "${timeout}" -e rbs "${playbuff}" -e pbs "${recbuff}" -e api "${api}" -e signal "${signal}" -e usage 14 -e atpm 1
+    testtype="systemfull"
+    if [[ $sdk_version -ge 29 ]]; then
+        adb shell am start -S -n com.facebook.audiolat/.MainActivity -e sr "${samplerate}" -e t "${timeout}" -e rbs "${playbuff}" -e pbs "${recbuff}" -e api "${api}" -e signal "${signal}" -e usage 14 -e atpm 1
+    else
+        adb shell am start -S -n com.facebook.audiolat.sdk28/com.facebook.audiolat.MainActivity -e sr "${samplerate}" -e t "${timeout}" -e rbs "${playbuff}" -e pbs "${recbuff}" -e api "${api}" -e signal "${signal}" -e usage 14 -e atpm 1
+    fi
 else
-    adb shell am start -S -n com.facebook.audiolat/.MainActivity -e sr "${samplerate}" -e t "${timeout}" -e rbs "${playbuff}" -e pbs "${recbuff}" -e api "${api}" -e signal "${signal}" -e usage 14 -e atpm 1 -e midi 1 -e midiid ${midi}
+    testtype="systemdown"
+    if [[ $sdk_version -ge 29 ]]; then
+        adb shell am start -S -n com.facebook.audiolat/.MainActivity -e sr "${samplerate}" -e t "${timeout}" -e rbs "${playbuff}" -e pbs "${recbuff}" -e api "${api}" -e signal "${signal}" -e usage 14 -e atpm 1 -e midi 1 -e midiid ${midi}
+    else
+        adb shell am start -S -n com.facebook.audiolat.sdk28/com.facebook.audiolat.MainActivity -e sr "${samplerate}" -e t "${timeout}" -e rbs "${playbuff}" -e pbs "${recbuff}" -e api "${api}" -e signal "${signal}" -e usage 14 -e atpm 1 -e midi 1 -e midiid ${midi}
+    fi
 fi
 sleep "${timeout}"
 # give me some startup margin
@@ -44,12 +61,20 @@ logfile="${wdir}/audiolat_${samplerate}Hz_${playbuff}_${recbuff}.logcat"
 match_log="${wdir}/audiolat_${samplerate}Hz_match_times.log"
 cp audiolat_tmp.txt ${logfile}
 rm audiolat_tmp.txt
-files=$(adb shell ls /sdcard/audiolat*.raw)
+
+if [[ $sdk_version -ge 29 ]]; then
+    files=$(adb shell ls /storage/emulated/0/Android/data/com.facebook.audiolat/files/audiolat*.raw)
+else
+    files=$(adb shell ls /storage/emulated/0/Android/data/com.facebook.audiolat.sdk28/files/audiolat*.raw)
+fi
 
 file=${files[0]}
 adb pull "${file}"
 input=${file##*/}
 output=${file##*/}.wav
+test_full_name=${testtype}.${test_id}
+echo "Full name is ${test_full_name}"
+
 ffmpeg -f s16le -ar "${samplerate}" -i "${input}" -ar "${samplerate}"  "${output}" -y
 
 begin_signal="${sdir}/../audio/begin_signal.wav"
@@ -60,17 +85,17 @@ if [ -z ${midi} ]; then
     "${sdir}/find_pulses.py" "${begin_signal}" "${end_signal}" -i "${output}" --limit_marker 0.03 -t 80,50
     "${sdir}/calc_delay.py"  "${output}.csv" -o "${wdir}/${test_id}.match.csv" > "${match_log}"
 fi
-echo "parse data to ${test_id}.mean.csv"
-echo "${sdir}/parse_data.sh ${logfile} ${match_log} ${samplerate} ${wdir}/${test_id}.mean.csv"
-device=$("${sdir}/parse_data.sh" "${logfile}" "${match_log}" "${samplerate}" "${test_id}.mean.csv")
+device=$("${sdir}/parse_data.sh" "${logfile}" "${match_log}" "${samplerate}" "${test_full_name}.settings.csv")
+
 echo "Change names"
-mv ${output} ${device}.${test_id}.wav
-mv ${output}.csv ${device}.${test_id}.csv
-mv ${logfile} ${device}.${test_id}.logcat
+echo "mv ${output} ${test_full_name}.wav"
+mv ${output} ${device}.${test_full_name}.wav
+mv ${output}.csv ${device}.${test_full_name}.csv
+mv ${logfile} ${device}.${test_full_name}.logcat
 
 if ! [ -z ${midi} ]; then
-    find_transient.py -m "${end_signal}" -t 50 --limit_marker 0.03 "${device}.${test_id}.wav"
+    find_transient.py -m "${end_signal}" -t 50 --limit_marker 0.03 "${device}.${test_full_name}.wav" 
 else
-    mv "${wdir}/${test_id}.match.csv" "${wdir}/${device}.${test_id}.match.csv"
+    mv "${wdir}/${test_id}.match.csv" "${wdir}/${device}.${test_full_name}.match.csv"
 fi
 rm ${input}


### PR DESCRIPTION
The native midi is not available for sdk older than 29.
Instead run java midi for those devices.
The gradle build now have two targets:
* audiolat and
* audiolat_sdk28.

The write path for the files have been moved into the appliaction
folder to simplify version handling.
I can be found at:
/storage/emulated/0/Android/data/com.facebook.audiolat/files/